### PR TITLE
Correctly test for `NaN`.

### DIFF
--- a/parse.js
+++ b/parse.js
@@ -102,7 +102,7 @@ var num: Parser<number> = seq(
     ]), ret(""))
   ]), (s) => {
     var n = parseFloat(s);
-    return n == NaN ? fail : ret(n);
+    return isNaN(n) ? fail : ret(n);
   });
 
 function makeParser<A>(p: Parser<A>): ((s: string) => A) {


### PR DESCRIPTION
`NaN === NaN` evaluates to `false` (hence, `isNaN` has to be used).
